### PR TITLE
Move IndexResult to own module with unit tests

### DIFF
--- a/src/index_result.rs
+++ b/src/index_result.rs
@@ -1,0 +1,47 @@
+use std::{collections::HashMap, fmt};
+
+pub struct IndexResult {
+    pub cid: String,
+    pub title: String,
+    pub excerpt: String,
+    pub keywords: HashMap<String, u32>,
+}
+
+impl IndexResult {
+    pub fn new(
+        cid: String,
+        title: String,
+        excerpt: String,
+        keywords: HashMap<String, u32>,
+    ) -> IndexResult {
+        IndexResult {
+            cid: cid,
+            title: title,
+            excerpt: excerpt,
+            keywords: keywords,
+        }
+    }
+
+    /**
+     * Returns the top n keywords. Todo: use a tree structure to store the rankings of the keywords
+     * so that this is faster
+     */
+    pub fn top_n_keywords(&self, n: u32) -> Vec<(&String, &u32)> {
+        let mut hash_vec: Vec<(&String, &u32)> = self.keywords.iter().collect();
+        hash_vec.sort_by(|a, b| b.1.cmp(a.1));
+        hash_vec.iter().take(n as usize).cloned().collect()
+    }
+}
+
+impl fmt::Display for IndexResult {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "CID: {} \nTitle: {}\n{}\nKeywords: {:?}",
+            self.cid,
+            self.title,
+            self.excerpt,
+            self.top_n_keywords(10)
+        )
+    }
+}

--- a/src/index_result.rs
+++ b/src/index_result.rs
@@ -48,8 +48,21 @@ impl fmt::Display for IndexResult {
 
 #[cfg(test)]
 mod tests {
+    use std::array::IntoIter;
+    use std::{collections::HashMap, iter::FromIterator};
+
+    use crate::index_result::IndexResult;
+
     #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
+    fn single_keyword() {
+        let keywords = HashMap::<_, _>::from_iter(IntoIter::new([("key1".to_string(), 1)]));
+
+        let result = IndexResult::new(
+            "1".to_string(),
+            "title".to_string(),
+            "excerpt".to_string(),
+            keywords,
+        );
+        assert_eq!(result.top_n_keywords(10).len(), 1);
     }
 }

--- a/src/index_result.rs
+++ b/src/index_result.rs
@@ -65,4 +65,37 @@ mod tests {
         );
         assert_eq!(result.top_n_keywords(10).len(), 1);
     }
+    #[test]
+
+    fn all_keywords() {
+        let keywords = HashMap::<_, _>::from_iter(IntoIter::new([
+            ("key1".to_string(), 1),
+            ("key2".to_string(), 2),
+        ]));
+
+        let result = IndexResult::new(
+            "1".to_string(),
+            "title".to_string(),
+            "excerpt".to_string(),
+            keywords,
+        );
+        assert_eq!(result.top_n_keywords(2).len(), 2);
+    }
+
+    #[test]
+    fn subset_of_keywords() {
+        let keywords = HashMap::<_, _>::from_iter(IntoIter::new([
+            ("key1".to_string(), 1),
+            ("key2".to_string(), 2),
+            ("key2".to_string(), 3),
+        ]));
+
+        let result = IndexResult::new(
+            "1".to_string(),
+            "title".to_string(),
+            "excerpt".to_string(),
+            keywords,
+        );
+        assert_eq!(result.top_n_keywords(2).len(), 2);
+    }
 }

--- a/src/index_result.rs
+++ b/src/index_result.rs
@@ -45,3 +45,11 @@ impl fmt::Display for IndexResult {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1,13 +1,13 @@
 use chashmap::CHashMap;
-use std::sync::mpsc::{channel, Receiver, Sender};
-use std::{sync, thread, time};
-use std::sync::atomic::{AtomicBool, Ordering};
 use cid::multihash::{Code, MultihashDigest};
 use cid::Cid;
-use log::{trace,info,warn};
-use std::fmt;
-use scraper::{Html,Selector};
+use log::{info, trace, warn};
+use scraper::{Html, Selector};
 use std::collections::HashMap;
+use std::fmt;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{channel, Receiver, Sender};
+use std::{sync, thread, time};
 
 pub const RAW: u64 = 0x55;
 
@@ -15,16 +15,21 @@ struct IndexResult {
     pub cid: String,
     pub title: String,
     pub excerpt: String,
-    pub keywords: HashMap<String, u32>
+    pub keywords: HashMap<String, u32>,
 }
 
 impl IndexResult {
-    pub fn new(cid: String, title: String, excerpt: String, keywords: HashMap<String, u32>) -> IndexResult {
+    pub fn new(
+        cid: String,
+        title: String,
+        excerpt: String,
+        keywords: HashMap<String, u32>,
+    ) -> IndexResult {
         IndexResult {
             cid: cid,
             title: title,
             excerpt: excerpt,
-            keywords: keywords
+            keywords: keywords,
         }
     }
 
@@ -32,7 +37,7 @@ impl IndexResult {
      * Returns the top n keywords. Todo: use a tree structure to store the rankings of the keywords
      * so that this is faster
      */
-    pub fn top_n_keywords(&self, n: u32) -> Vec<(&String, &u32)>{
+    pub fn top_n_keywords(&self, n: u32) -> Vec<(&String, &u32)> {
         let mut hash_vec: Vec<(&String, &u32)> = self.keywords.iter().collect();
         hash_vec.sort_by(|a, b| b.1.cmp(a.1));
         hash_vec.iter().take(n as usize).cloned().collect()
@@ -41,7 +46,14 @@ impl IndexResult {
 
 impl fmt::Display for IndexResult {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "CID: {} \nTitle: {}\n{}\nKeywords: {:?}", self.cid, self.title, self.excerpt, self.top_n_keywords(10))
+        write!(
+            f,
+            "CID: {} \nTitle: {}\n{}\nKeywords: {:?}",
+            self.cid,
+            self.title,
+            self.excerpt,
+            self.top_n_keywords(10)
+        )
     }
 }
 
@@ -70,7 +82,7 @@ impl Indexer {
             running: sync::Arc::new(AtomicBool::new(false)),
             handle: None,
             poison_pill: Cid::new_v1(RAW, Code::Sha2_256.digest(b"Poison Pill")),
-            ipfs_gateway: ipfs_gateway
+            ipfs_gateway: ipfs_gateway,
         }
     }
 
@@ -127,7 +139,12 @@ impl Indexer {
                     if res.0.is_some() {
                         map.insert(cid.clone(), res.0.unwrap());
                     }
-                    info!("indexed cid {}. Have {} entries. Have {} more cids to add to the queue", cid, map.len(),  res.1.len());
+                    info!(
+                        "indexed cid {}. Have {} entries. Have {} more cids to add to the queue",
+                        cid,
+                        map.len(),
+                        res.1.len()
+                    );
                     for new_cid in res.1 {
                         if map.contains_key(&new_cid) {
                             trace!("cid {} already in map", new_cid);
@@ -152,7 +169,7 @@ impl Indexer {
         let url = format!("http://{}/ipfs/{}", gateway, cid);
         info!("retreiving content from {}", url);
         let client = reqwest::blocking::Client::new();
-        
+
         let result = client.get(&url).send();
         let result = match result {
             Ok(r) => r,
@@ -184,7 +201,10 @@ impl Indexer {
             } else {
                 info!("found meta http-equiv=\"refresh\"");
                 let start_bytes = inner_html.find("url=").unwrap_or(0);
-                let end_bytes = inner_html[start_bytes..].find("\"").unwrap_or(inner_html.len()) + start_bytes;
+                let end_bytes = inner_html[start_bytes..]
+                    .find("\"")
+                    .unwrap_or(inner_html.len())
+                    + start_bytes;
                 let redirect_url = &inner_html[start_bytes + 4..end_bytes];
                 // assuming relative
                 let newurl = format!("{}/{}", url, redirect_url);
@@ -220,11 +240,11 @@ impl Indexer {
         for element in document.select(&selector) {
             let link = element.value().attr("href").unwrap_or("");
             if link.starts_with(format!("http://{}/ipfs/", gateway).as_str()) {
-                let cid = link[12 + gateway.len() ..].to_string();
+                let cid = link[12 + gateway.len()..].to_string();
                 info!("found link to {}", cid);
                 cids.push(cid);
             } else if link.starts_with(format!("https://{}/ipfs/", gateway).as_str()) {
-                let cid = link[13 + gateway.len() ..].to_string();
+                let cid = link[13 + gateway.len()..].to_string();
                 info!("found link to {}", cid);
                 cids.push(cid);
             } else if link.starts_with("http") || link.starts_with("https") {
@@ -245,14 +265,14 @@ impl Indexer {
         let selector = Selector::parse("body").unwrap();
         let body = document.select(&selector).next();
         let mut excerpt = "".to_string();
-        let mut keywords : HashMap<String, u32> = HashMap::new();
+        let mut keywords: HashMap<String, u32> = HashMap::new();
         if body.is_some() {
             // collect up the tags in the body, and get the contents within them without their tags
             let inner = body.unwrap().text().collect::<Vec<_>>();
             let mut content = inner.join(" ");
             // this leaves a ton of whitespace between things, so do this next step to remove that
             let iter = content.split_whitespace();
-            content = iter.fold(String::new(), | a,b| a + b + " ");
+            content = iter.fold(String::new(), |a, b| a + b + " ");
             content = content.trim_start().trim_end().to_string();
 
             // get the frequency of words and turn it into a btree
@@ -269,7 +289,7 @@ impl Indexer {
                     }
                 }
             }
-            
+
             if content.contains("no link named") {
                 warn!("ipfs error on page {}, likely doesn't exist", fullcid);
             }
@@ -282,7 +302,7 @@ impl Indexer {
         info!("retreived content for cid {}:\n{}", cid, result);
         (Some(result), cids)
     }
-    
+
     pub fn stop(&mut self) {
         if !self.running.load(Ordering::SeqCst) {
             warn!("trying to stop before indexer started");

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1,61 +1,15 @@
+use super::index_result::IndexResult;
 use chashmap::CHashMap;
 use cid::multihash::{Code, MultihashDigest};
 use cid::Cid;
 use log::{info, trace, warn};
 use scraper::{Html, Selector};
 use std::collections::HashMap;
-use std::fmt;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::{sync, thread, time};
 
 pub const RAW: u64 = 0x55;
-
-struct IndexResult {
-    pub cid: String,
-    pub title: String,
-    pub excerpt: String,
-    pub keywords: HashMap<String, u32>,
-}
-
-impl IndexResult {
-    pub fn new(
-        cid: String,
-        title: String,
-        excerpt: String,
-        keywords: HashMap<String, u32>,
-    ) -> IndexResult {
-        IndexResult {
-            cid: cid,
-            title: title,
-            excerpt: excerpt,
-            keywords: keywords,
-        }
-    }
-
-    /**
-     * Returns the top n keywords. Todo: use a tree structure to store the rankings of the keywords
-     * so that this is faster
-     */
-    pub fn top_n_keywords(&self, n: u32) -> Vec<(&String, &u32)> {
-        let mut hash_vec: Vec<(&String, &u32)> = self.keywords.iter().collect();
-        hash_vec.sort_by(|a, b| b.1.cmp(a.1));
-        hash_vec.iter().take(n as usize).cloned().collect()
-    }
-}
-
-impl fmt::Display for IndexResult {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "CID: {} \nTitle: {}\n{}\nKeywords: {:?}",
-            self.cid,
-            self.title,
-            self.excerpt,
-            self.top_n_keywords(10)
-        )
-    }
-}
 
 pub struct Indexer {
     // this map is for keeping track of which entries have been indexed

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,11 @@
-use futures::executor::block_on;
-use futures::prelude::*;
-use libp2p::ping::{Ping, PingConfig};
-use libp2p::swarm::{Swarm, SwarmEvent};
-use libp2p::{identity, PeerId};
-use std::error::Error;
-use std::task::Poll;
 use cid::Cid;
-use log::{info,warn};
+use futures::executor::block_on;
+use libp2p::{identity, PeerId};
+use log::{info, warn};
 use simple_logger::SimpleLogger;
 use std::convert::TryFrom;
 use std::env;
+use std::error::Error;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -31,7 +27,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         gateway = &args[1];
     }
 
-
     let mut index = Indexer::new(gateway.to_string());
     index.start();
 
@@ -39,16 +34,16 @@ fn main() -> Result<(), Box<dyn Error>> {
     // note: delays are so that we don't stop before the indexer has a chance to work, in reality we don't need them
     let wikipedia_cid = Cid::try_from("QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco").unwrap();
     index.enqueue_cid(wikipedia_cid);
-    
+
     let local_key = identity::Keypair::generate_ed25519();
     let local_peer_id = PeerId::from(local_key.public());
     info!("Local peer id: {:?}", local_peer_id);
 
-    let transport = block_on(libp2p::development_transport(local_key))?;
+    let _transport = block_on(libp2p::development_transport(local_key))?;
 
     // this stuff conflicts with the running ipfs node,
     // so need to rejig it otherwise it panics before indexing starts
-    
+
     // Create a ping network behaviour.
     //
     // For illustrative purposes, the ping protocol is configured to
@@ -87,7 +82,8 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     ctrlc::set_handler(move || {
         r.store(false, Ordering::SeqCst);
-    }).expect("Error setting Ctrl-C handler");
+    })
+    .expect("Error setting Ctrl-C handler");
 
     info!("Waiting for Ctrl-C...");
     while running.load(Ordering::SeqCst) {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,9 @@ use std::error::Error;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
+mod index_result;
 mod indexer;
+
 use indexer::Indexer;
 
 fn main() -> Result<(), Box<dyn Error>> {

--- a/src/mod.rs
+++ b/src/mod.rs
@@ -1,2 +1,0 @@
-mod index_result;
-pub use index_result::*;

--- a/src/mod.rs
+++ b/src/mod.rs
@@ -1,0 +1,2 @@
+mod index_result;
+pub use index_result::*;


### PR DESCRIPTION
- Isolate `IndexResult` into it's own module and surround it with unit tests
- Will allow swapping out of underlying frequency count algorithm / data structure easier
- Will follow up with a PR to add benchmarks to see compare before/after results of changing out implementation