### PR TITLE
Fix warning for immutable/mutable borrowing

### DIFF
--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -287,7 +287,7 @@ impl Indexer {
                 if word.len() > 3 {
                     let word = word.to_lowercase();
                     if keywords.contains_key(&word) {
-                        let count = keywords.get(&word).unwrap();
+                        let count = keywords.get(&word).cloned().unwrap();
                         keywords.insert(word, count + 1);
                     } else {
                         keywords.insert(word, 1);


### PR DESCRIPTION
Calling `get` on a mutable hashmap creates an immutable borrow,  calling `insert` on a mutable hashmap reference creates a mutable borrow. Rust doesn't like both, see: https://github.com/rust-lang/rust/issues/59159

Fix by cloning reference returned by `get`.