### PR TITLE
Minor cleanup, warnings and deprecations

### DIFF
--- a/src/index_queue.rs
+++ b/src/index_queue.rs
@@ -180,7 +180,7 @@ impl IndexQueue {
      * Process the content of the page, extract keywords, enqueue more cids, return the IndexResult
      */
     fn process_content(&self, gateway: String, cid: String, document: Html) -> Option<IndexResult> {
-        let mut fullcid = cid.clone();
+        let fullcid = cid.clone();
 
         let selector = Selector::parse("title").unwrap();
         let titletag = document.select(&selector).next();
@@ -218,7 +218,6 @@ impl IndexQueue {
         }
         let selector = Selector::parse("body").unwrap();
         let body = document.select(&selector).next();
-        let mut excerpt = "".to_string();
         let mut index_keywords: HashMap<String, u32> = HashMap::new();
         if body.is_some() {
             // collect up the tags in the body, and get the contents within them without their tags
@@ -258,7 +257,7 @@ impl IndexQueue {
             }
 
             let end = content.char_indices().map(|(i, _)| i).nth(128).unwrap();
-            excerpt = content[..end].to_string();
+            let excerpt = content[..end].to_string();
 
             return Some(IndexResult::new(
                 fullcid,

--- a/src/index_result.rs
+++ b/src/index_result.rs
@@ -63,12 +63,11 @@ impl fmt::Debug for IndexResult {
 #[cfg(test)]
 mod tests {
     use crate::index_result::IndexResult;
-    use std::array::IntoIter;
     use std::{collections::HashMap, iter::FromIterator};
 
     #[test]
     fn single_keyword() {
-        let keywords = HashMap::<_, _>::from_iter(IntoIter::new([("key1".to_string(), 1)]));
+        let keywords = HashMap::<_, _>::from_iter([("key1".to_string(), 1)]);
 
         let result = IndexResult::new(
             "1".to_string(),
@@ -81,10 +80,8 @@ mod tests {
     #[test]
 
     fn all_keywords() {
-        let keywords = HashMap::<_, _>::from_iter(IntoIter::new([
-            ("key1".to_string(), 1),
-            ("key2".to_string(), 2),
-        ]));
+        let keywords =
+            HashMap::<_, _>::from_iter([("key1".to_string(), 1), ("key2".to_string(), 2)]);
 
         let result = IndexResult::new(
             "1".to_string(),
@@ -97,11 +94,11 @@ mod tests {
 
     #[test]
     fn subset_of_keywords() {
-        let keywords = HashMap::<_, _>::from_iter(IntoIter::new([
+        let keywords = HashMap::<_, _>::from_iter([
             ("key1".to_string(), 1),
             ("key2".to_string(), 2),
             ("key2".to_string(), 3),
-        ]));
+        ]);
 
         let result = IndexResult::new(
             "1".to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
 use std::convert::TryFrom;
-use std::fmt::format;
 use std::sync::Arc;
 
 use threadpool::ThreadPool;


### PR DESCRIPTION
- Remove unnecessary `mut` declaration
- Define and assign `excerpt` on it's assignment, make immutable since it's not re-written
- Remove deprecated `IntoIter::new` allocations