### PR TITLE
Bump rust edition to 2021, ignore DS_Store (mac) files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .idea
+.DS_Store

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ipfs_indexer"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
- Bump rust edition from `2018` -> `2021`: https://doc.rust-lang.org/edition-guide/editions/index.html
- `gitignore` `DS_Store` files: https://en.wikipedia.org/wiki/.DS_Store