### PR TITLE
Enable Renovate auto-merge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,8 @@
 {
   "extends": [
     "config:base"
-  ]
+  ],
+  "automerge": true,
+  "automergeType": "pr",
+  "platformAutomerge": true
 }


### PR DESCRIPTION
Adds automerge, automergeType, and platformAutomerge to renovate.json so that Renovate PRs auto-merge after CI passes.